### PR TITLE
Add Important Items Map modlist

### DIFF
--- a/SiteData.json
+++ b/SiteData.json
@@ -41,7 +41,8 @@
 		"https://raw.githubusercontent.com/Data-0/ModsJson_And_Images/refs/heads/main/Data-0_Mods.json",
 		"https://raw.githubusercontent.com/okclm/ModListJson/refs/heads/main/okclm_tld_mods.json",
 		"https://raw.githubusercontent.com/TLD-Mods/ModLists/master/Probie_Pathoschild.json",
-		"https://raw.githubusercontent.com/TLD-Mods/ModLists/master/Probie_LittleWolfStorm.json"
+		"https://raw.githubusercontent.com/TLD-Mods/ModLists/master/Probie_LittleWolfStorm.json",
+		"https://gitlab.com/Ibadez38/importantitemsmap/-/raw/main/modlist.json"
 	],
 	"oldlists": [
 		"https://raw.githubusercontent.com/OceanManFR/ModList/master/oceanman.json",


### PR DESCRIPTION
Adds the Important Items Map modlist to SiteData.json.

Modlist URL:
https://gitlab.com/Ibadez38/importantitemsmap/-/raw/main/modlist.json

Mod repository:
https://gitlab.com/Ibadez38/importantitemsmap

Release DLL:
https://gitlab.com/Ibadez38/importantitemsmap/-/releases/v1.0.0/downloads/ImportantItemsMap.dll